### PR TITLE
'Back to Editor' button smoothly generates modal with edited record

### DIFF
--- a/modules/error_flag-1-main.R
+++ b/modules/error_flag-1-main.R
@@ -90,8 +90,8 @@ edit_interface_server <- function(id, edit_persons) {
                      div(class = "trip-buttons-panel",
                          modal_new_trip_ui(ns('button_new')),
                          
-                         actionButton(ns('edit_button'),
-                                      label = "Edit Trip"),
+                         div(actionButton(ns('edit_button'),
+                                          label = "Edit Trip")),
                          
                          modal_delete_trip_ui(ns('button_delete'))
                      ) # end div

--- a/modules/error_flag-1-main.R
+++ b/modules/error_flag-1-main.R
@@ -18,7 +18,10 @@ edit_interface_server <- function(id, edit_persons) {
     # the trip table ----
     
     # person data from database
-    edit_dt <- reactive({get_data(person_id = personID())})
+    edit_dt <- reactive({
+      get_data(person_id = personID())
+      })
+    
     output$thetable <- DT::renderDataTable(
       edit_dt()[,view.cols],
       options =list(ordering = F, dom = 't'), 
@@ -26,18 +29,49 @@ edit_interface_server <- function(id, edit_persons) {
       rownames = FALSE, 
       server=TRUE)
     
+    observeEvent(input$edit_button, {
+      # display modal if 0 records were selected
+      
+      if(is.null(input$thetable_rows_selected)) {
+        showModal(
+          modalDialog(
+            title = "0 records have been selected",
+            easy_close = FALSE,
+            "Please select a record from the table below to continue."
+          )
+        )
+      }
+    })
+    
     # data cleaning tools ----
     
-    selected_row_recid <- reactive({ edit_dt()[input$thetable_rows_selected,"recid"] })
+    selected_row_recid <- eventReactive(input$edit_button, {
+      edit_dt()[input$thetable_rows_selected, "recid"]
+    })
     
     ## button to add new trip
-    modal_new_trip_server("button_new",       selected_recid = reactive(selected_row_recid()))
-    ## button to edit trip
-    modal_edit_trip_server("button_edit",     selected_recid = reactive(selected_row_recid()))
+    modal_new_trip_server("button_new",       
+                          selected_recid = reactive(selected_row_recid()))
+
+    ## activate Edit Trip modal
+    observeEvent(input$edit_button, {
+      ## button is separated from the rest of the edit modal 
+      ## show modal if no records were selected
+      
+      if(!is.null(input$thetable_rows_selected))
+        
+        modal_edit_trip_server("button_edit",
+                               selected_recid = reactive(selected_row_recid())
+        )
+    })
+    
+    
     ## button to delete trip
-    modal_delete_trip_server("button_delete", selected_recid = reactive(selected_row_recid()))
+    modal_delete_trip_server("button_delete", 
+                             selected_recid = reactive(selected_row_recid()))
     ## trip linking interface
-    modal_trip_linking_server("button_link",  selected_recid = reactive(selected_row_recid()))
+    modal_trip_linking_server("button_link",  
+                              selected_recid = reactive(selected_row_recid()))
     
     # platform layout ----
     
@@ -55,7 +89,10 @@ edit_interface_server <- function(id, edit_persons) {
                      p("Select one trip in trip table below to edit"),
                      div(class = "trip-buttons-panel",
                          modal_new_trip_ui(ns('button_new')),
-                         modal_edit_trip_ui(ns('button_edit')),
+                         
+                         actionButton(ns('edit_button'),
+                                      label = "Edit Trip"),
+                         
                          modal_delete_trip_ui(ns('button_delete'))
                      ) # end div
                    ), # end wellpanel

--- a/modules/error_flag-4-modal_edit_trip-update_button-pause.R
+++ b/modules/error_flag-4-modal_edit_trip-update_button-pause.R
@@ -9,12 +9,6 @@ modal_update_trip_server <- function(id, all_input, recid) {
   moduleServer(id, function(input, output, session){
     ns <- session$ns
     
-    v <- reactiveValues(btnedit = 0)
-    
-    observeEvent(input$button_edit_again, {
-      v$btnedit <- v$btnedit + 1
-    })
-    
     orig_trip_record <- reactive({ 
       get_data(view_name = "Trip", recid = recid) 
     })
@@ -121,9 +115,8 @@ modal_update_trip_server <- function(id, all_input, recid) {
     observeEvent(input$button_edit_again, {
       removeModal()
       modal_edit_trip_server("revise-trip", 
-                             selected_recid = recid(), 
+                             selected_recid = reactive(recid), 
                              updated_trip = update_trip())
-                             # updated_trip = reactive(update_trip()))
     })
       
     output$updatebutton <- renderUI({

--- a/modules/error_flag-4-modal_edit_trip-update_button-pause.R
+++ b/modules/error_flag-4-modal_edit_trip-update_button-pause.R
@@ -14,7 +14,7 @@ modal_update_trip_server <- function(id, all_input, recid) {
     })
     
     # create comparison table showing edited data
-    compare_table <- eventReactive(input$clickupdate | input$button_edit_again, {
+    compare_table <- eventReactive(input$clickupdate, {
 
       # get all editable variables
       all_vars_input_names <- names(all_input)[grepl("data_edit-", names(all_input))]

--- a/modules/error_flag-4-modal_edit_trip-update_button-pause.R
+++ b/modules/error_flag-4-modal_edit_trip-update_button-pause.R
@@ -9,11 +9,19 @@ modal_update_trip_server <- function(id, all_input, recid) {
   moduleServer(id, function(input, output, session){
     ns <- session$ns
     
-    trip_record <- reactive({ get_data(view_name="Trip", recid=recid) })
+    v <- reactiveValues(btnedit = 0)
+    
+    observeEvent(input$button_edit_again, {
+      v$btnedit <- v$btnedit + 1
+    })
+    
+    orig_trip_record <- reactive({ 
+      get_data(view_name = "Trip", recid = recid) 
+    })
     
     # create comparison table showing edited data
-    compare_table <- reactive({
-      
+    compare_table <- eventReactive(input$clickupdate | input$button_edit_again, {
+
       # get all editable variables
       all_vars_input_names <- names(all_input)[grepl("data_edit-", names(all_input))]
       all_vars <- str_remove(all_vars_input_names,"data_edit-")
@@ -24,14 +32,15 @@ modal_update_trip_server <- function(id, all_input, recid) {
         var_name <- all_vars[i]
         var_input_name <- all_vars_input_names[i]
         # create df with original and updated values
-        compare_table <- as.data.frame(rbind(compare_table,
-                                             cbind(var_name,
-                                                   # original value
-                                                   trip_record()[[var_name]],
-                                                   # updated value
-                                                   all_input[[var_input_name]]
-                                                   ))
-                                       )
+        compare_table <- as.data.frame(
+          rbind(compare_table,
+                cbind(var_name,
+                      # original value
+                      orig_trip_record()[[var_name]],
+                      # updated value
+                      all_input[[var_input_name]]
+                ))
+        )
       }
       names(compare_table) <- c("Variable","Original Value","Updated Value")
       
@@ -40,50 +49,54 @@ modal_update_trip_server <- function(id, all_input, recid) {
         mutate(mod=case_when(`Original Value`==`Updated Value`~0,
                              TRUE~1))
       
-      compare_table
+      return(compare_table)
       })
     
     # create updated trip record
-    update_trip <- reactive({
+    update_trip <- eventReactive(input$clickupdate, {
       
       # get all editable variables
       all_vars_input_names <- names(all_input)[grepl("data_edit-", names(all_input))]
       all_vars <- str_remove(all_vars_input_names,"data_edit-")
       
       trip <- NULL
-      for(var_name in names(trip_record())){
+      for(var_name in names(orig_trip_record())){
         if(var_name %in% all_vars){
           trip <- as.data.frame(cbind(trip,
                                       all_input[[paste0("data_edit-",var_name)]]
           ))
         } else{
           trip <- as.data.frame(cbind(trip,
-                                      trip_record()[[var_name]]
+                                      orig_trip_record()[[var_name]]
           ))
         }
       }
-      names(trip) <- names(trip_record())
+      names(trip) <- names(orig_trip_record())
       
       return(trip)
     })
     
- 
-    # print all comparison table
-    output$print_cols <- renderDataTable(
-      datatable(compare_table(),
-                options =list(ordering = F, dom = 't', pageLength =-1,
-                              # hide mod column
-                              columnDefs = list(list(targets = 4,visible = FALSE)))
-                ) %>% 
-        formatStyle(
-        'mod',
-        target = 'row',
-        backgroundColor = styleEqual(c(0, 1), c('white', '#00A7A0'))
-      )
-     )
-    
-    
     observeEvent(input$clickupdate, { 
+      removeModal()
+      
+      # print all comparison table
+      output$print_cols <- renderDT({
+
+          datatable(compare_table(),
+                    options =list(ordering = F,
+                                  dom = 't',
+                                  pageLength = -1,
+                                  # hide mod column
+                                  columnDefs = list(list(targets = 4,visible = FALSE)))
+          ) %>%
+            formatStyle(
+              'mod',
+              target = 'row',
+              backgroundColor = styleEqual(c(0, 1), c('white', '#00A7A0'))
+            )
+
+      })
+      
       showModal(
         modalDialog(title = "Update Trip Record Preview",
                     #TODO: add trip summary
@@ -106,15 +119,17 @@ modal_update_trip_server <- function(id, all_input, recid) {
     })
     
     observeEvent(input$button_edit_again, {
+      removeModal()
       modal_edit_trip_server("revise-trip", 
                              selected_recid = recid(), 
-                             updated_trip = reactive(update_trip()))
+                             updated_trip = update_trip())
+                             # updated_trip = reactive(update_trip()))
     })
       
-    output$updatebutton <- renderUI({ 
-      actionButton(ns("clickupdate"), 
-                   "Apply Changes") 
-      }) 
+    output$updatebutton <- renderUI({
+      actionButton(ns("clickupdate"),
+                   "Apply Changes")
+      })
     
   })  # end moduleServer
 }

--- a/modules/error_flag-4-modal_edit_trip-update_button-pause.R
+++ b/modules/error_flag-4-modal_edit_trip-update_button-pause.R
@@ -11,10 +11,6 @@ modal_update_trip_server <- function(id, all_input, recid) {
     
     trip_record <- reactive({ get_data(view_name="Trip", recid=recid) })
     
-    
-    # featured buttons ----
-    # modal_edit_trip_server("button_edit_again", selected_row = recid(), updated_trip = reactive(update_trip()))
-    
     # create comparison table showing edited data
     compare_table <- reactive({
       
@@ -59,18 +55,16 @@ modal_update_trip_server <- function(id, all_input, recid) {
         if(var_name %in% all_vars){
           trip <- as.data.frame(cbind(trip,
                                       all_input[[paste0("data_edit-",var_name)]]
-                                      ))
+          ))
         } else{
           trip <- as.data.frame(cbind(trip,
                                       trip_record()[[var_name]]
-                                      ))
-          
+          ))
         }
-        
       }
       names(trip) <- names(trip_record())
       
-      trip
+      return(trip)
     })
     
  
@@ -89,23 +83,38 @@ modal_update_trip_server <- function(id, all_input, recid) {
      )
     
     
-    observeEvent(input$clickupdate, { showModal(
-      modalDialog(title = "Update Trip Record Preview",
-                  #TODO: add trip summary
-                  div(
-                    DTOutput(ns('print_cols'))
-                  ),
-                  
-                  footer = column(modalButton('Close'),
-                                  # go back to edit trip modal
-                                  # modal_edit_trip_ui(ns('button_edit_again')),
-                                  width=12),
-                  easyClose = TRUE,
-                  size = "l"
-      )
-    ) })
+    observeEvent(input$clickupdate, { 
+      showModal(
+        modalDialog(title = "Update Trip Record Preview",
+                    #TODO: add trip summary
+                    div(
+                      DTOutput(ns('print_cols'))
+                    ),
+                    
+                    footer = div(
+                      style = "display: flex; justify-content: space-between;",
+                      
+                      actionButton(ns('button_edit_again'),
+                                   label = "Back to Editor"),
+                      
+                      modalButton('Close')
+                    ),
+                    easyClose = TRUE,
+                    size = "l"
+        )
+      ) 
+    })
     
-    output$updatebutton <- renderUI({ actionButton(ns("clickupdate"), "Apply Changes") }) 
+    observeEvent(input$button_edit_again, {
+      modal_edit_trip_server("revise-trip", 
+                             selected_recid = recid(), 
+                             updated_trip = reactive(update_trip()))
+    })
+      
+    output$updatebutton <- renderUI({ 
+      actionButton(ns("clickupdate"), 
+                   "Apply Changes") 
+      }) 
     
   })  # end moduleServer
 }

--- a/modules/error_flag-4-modal_edit_trip.R
+++ b/modules/error_flag-4-modal_edit_trip.R
@@ -12,9 +12,7 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
     trip_record <-  reactive({
       
       if(!is.null(updated_trip)){ # updated_trip is provided when coming back from update preview modal
-        # browser()
         return(updated_trip)
-        # return(updated_trip())
       } else {
         return(get_data(view_name = "Trip", recid = selected_recid()))
       }
@@ -28,8 +26,7 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
     
     # show basic trip information ----
     output$trip_summary <- DT::renderDT({
-      # if(!is.null(updated_trip))browser()
-      
+
       df <- trip_record() %>% 
         select(hhid, pernum, person_id, tripnum, recid)
       

--- a/modules/error_flag-4-modal_edit_trip.R
+++ b/modules/error_flag-4-modal_edit_trip.R
@@ -12,10 +12,11 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
     trip_record <-  reactive({
       
       if(!is.null(updated_trip)){ # updated_trip is provided when coming back from update preview modal
-        updated_trip()
-      }
-      else{
-        get_data(view_name="Trip", recid=selected_recid())
+        # browser()
+        return(updated_trip)
+        # return(updated_trip())
+      } else {
+        return(get_data(view_name = "Trip", recid = selected_recid()))
       }
       
     })
@@ -26,10 +27,17 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
     modal_update_trip_server("button-update_db", all_input=input, recid=selected_recid())
     
     # show basic trip information ----
-    output$trip_summary <- DT::renderDT(
-      trip_record() %>% select(hhid,pernum,person_id,tripnum,recid), 
-      rownames = FALSE,
-      options =list(ordering = F, dom = 't',  selection = 'single', pageLength =-1))
+    output$trip_summary <- DT::renderDT({
+      # if(!is.null(updated_trip))browser()
+      
+      df <- trip_record() %>% 
+        select(hhid, pernum, person_id, tripnum, recid)
+      
+      datatable(df, 
+                rownames = FALSE,
+                options =list(ordering = F, dom = 't',  selection = 'single', pageLength =-1)
+      )
+    })
     
     # Trip Record Editor ----
 

--- a/modules/error_flag-4-modal_edit_trip.R
+++ b/modules/error_flag-4-modal_edit_trip.R
@@ -3,8 +3,6 @@
 modal_edit_trip_ui <- function(id) {
   ns <- NS(id)
   
-  uiOutput(ns("editbutton"))
-  
 }
 
 modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NULL) {
@@ -34,11 +32,8 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
       options =list(ordering = F, dom = 't',  selection = 'single', pageLength =-1))
     
     # Trip Record Editor ----
-      observeEvent(input$clickedit, { 
-        
-        # if a row is selected in table: show Trip Record Editor
-        if(!identical(selected_recid(),integer(0))){
-          # browser()
+
+    observe({
           showModal(
             modalDialog(title = "Trip Record Editor",
                         
@@ -180,25 +175,8 @@ modal_edit_trip_server <- function(id, selected_recid = NULL, updated_trip = NUL
                                         modalButton('Cancel')),
                         # easyClose = TRUE,
                         size = "l"
-            ))}
-        # if no row is selected
-          else{
-            showModal(
-              modalDialog(
-                title = "0 records have been selected",
-                easy_close = TRUE,
-                "Please select a record from the table below to continue."
-              )
-            )
-          }
-        }
-        
-        )
-      
-      
-    
-
-    output$editbutton <- renderUI({  actionButton(ns("clickedit"), "Edit trip") }) 
+            ))
+          })
     
   })  # end moduleServer
 }

--- a/shiny-fixie.Rproj
+++ b/shiny-fixie.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: df56eeab-72d8-4acb-8fdf-d0bc52204b90
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Not a solution, but an idea. Still ends in error but not a 'recursive error'. When you click on the button 'Back to Editor', it will flash several times with the editor, your updated changes, and this error msg:

![image](https://github.com/user-attachments/assets/6766d65e-4409-454e-8163-2ee31a1cc1fe)

Again, I had to separate buttons (the action) from the display.

 Just wanted to share to see if it sparks other ideas.