### PR TITLE
handle datetime2/POSIXct values in trip edits

### DIFF
--- a/functions/db_connection.R
+++ b/functions/db_connection.R
@@ -14,5 +14,5 @@ get_data <- function(view_name="data2fixie_test", person_id=NULL, recid=NULL){
     query <- paste0("select * from HHSurvey.",view_name)
   }
   
-  return(get_query(sql = query, db_name = "hhts_cleaning"))
+  return(get_query(sql = query, db_name = "hhts_cleaning_temporal"))
 }

--- a/functions/db_connection.R
+++ b/functions/db_connection.R
@@ -14,5 +14,5 @@ get_data <- function(view_name="data2fixie_test", person_id=NULL, recid=NULL){
     query <- paste0("select * from HHSurvey.",view_name)
   }
   
-  return(get_query(sql = query, db_name = "hhts_cleaning_temporal"))
+  return(get_query(sql = query, db_name = "hhts_cleaning"))
 }

--- a/functions/db_connection.R
+++ b/functions/db_connection.R
@@ -14,5 +14,5 @@ get_data <- function(view_name="data2fixie_test", person_id=NULL, recid=NULL){
     query <- paste0("select * from HHSurvey.",view_name)
   }
   
-  return(get_query(sql = query, db_name = "hhts_cleaning"))
+  return(get_query(sql = query, db_name = "hhts_cleaning_dev"))
 }

--- a/functions/input_controls.R
+++ b/functions/input_controls.R
@@ -40,6 +40,71 @@ textInputSimple <- function(df, var_name, label_name = NULL, ...){
             ...)
 }
 
+# datetime input - specialized for timestamp columns with proper date/time controls
+datetimeInputSimple <- function(df, var_name, label_name = NULL, ...){
+  
+  var_str <- gsub("^.*-", "", var_name)
+  if(is.null(label_name)){
+    label_name = var_str
+  }
+  
+  # Get the datetime value and parse it properly
+  datetime_val <- df[1, c(var_str)]
+  
+  # Parse datetime value
+  parsed_datetime <- if(is.null(datetime_val) || is.na(datetime_val)) {
+    Sys.time()  # Default to current time if no value
+  } else {
+    tryCatch({
+      as.POSIXct(datetime_val)
+    }, error = function(e) {
+      Sys.time()  # Default to current time if parsing fails
+    })
+  }
+  
+  # Extract date and time components
+  date_part <- as.Date(parsed_datetime)
+  time_part <- format(parsed_datetime, "%H:%M:%S")
+  
+  # Create a container with both date and time inputs
+  div(
+    style = "margin-bottom: 15px;",
+    tags$label(class = "control-label", `for` = paste0(var_name, "_date"), label_name),
+    br(),
+    fluidRow(
+      column(6,
+        dateInput(inputId = paste0(var_name, "_date"),
+                 label = "Date",
+                 value = date_part,
+                 format = "yyyy-mm-dd")
+      ),
+      column(6,
+        textInput(inputId = paste0(var_name, "_time"),
+                 label = "Time (HH:MM:SS)",
+                 value = time_part,
+                 placeholder = "HH:MM:SS")
+      )
+    )
+  )
+}
+
+# Helper function to validate datetime format
+validate_datetime <- function(datetime_string) {
+  if(is.null(datetime_string) || datetime_string == "") {
+    return(list(valid = TRUE, message = ""))
+  }
+  
+  tryCatch({
+    parsed_date <- as.POSIXct(datetime_string)
+    if(is.na(parsed_date)) {
+      return(list(valid = FALSE, message = "Invalid datetime format. Please use YYYY-MM-DD HH:MM:SS"))
+    }
+    return(list(valid = TRUE, message = ""))
+  }, error = function(e) {
+    return(list(valid = FALSE, message = "Invalid datetime format. Please use YYYY-MM-DD HH:MM:SS"))
+  })
+}
+
 # number input
 numericInputSimple <- function(df, var_name, label_name = NULL, min = NA, max = NA, ...){
   

--- a/modules/error_flag-4-modal_edit_trip-revision.R
+++ b/modules/error_flag-4-modal_edit_trip-revision.R
@@ -67,9 +67,8 @@ modal_revise_trip_server <- function(id, selected_recid_revise, updated_trip) {
             fluidRow(
               class = "bottom-spacing",
               # timestamps
-              # TODO: find better way to select date and time
-              column(6, textInputSimple(df = rval$updated_trip, var_name = ns("data_edit-depart_time_timestamp")),
-                     textInputSimple(df = rval$updated_trip, var_name = ns("data_edit-arrival_time_timestamp"))),
+              column(6, datetimeInputSimple(df = rval$updated_trip, var_name = ns("data_edit-depart_time_timestamp")),
+                     datetimeInputSimple(df = rval$updated_trip, var_name = ns("data_edit-arrival_time_timestamp"))),
               # trip distance
               column(6, numericInputSimple(df = rval$updated_trip, var_name = ns("data_edit-distance_miles"), min = 0))),
 

--- a/modules/error_flag-4-modal_edit_trip-update_preview.R
+++ b/modules/error_flag-4-modal_edit_trip-update_preview.R
@@ -70,14 +70,22 @@ modal_update_trip_server <- function(id, trip_editor_input, selected_recid) {
           }
           
           # Compare original datetime with combined updated value
+          # Handle datetime2(0) precision by truncating to seconds for comparison
           is_modified <- if(is.null(orig_val) || is.na(orig_val)) {
             !is.na(combined_datetime)
           } else if(is.na(combined_datetime)) {
             TRUE
           } else {
             tryCatch({
+              # Parse original datetime and truncate to seconds (matching datetime2(0))
               orig_datetime <- as.POSIXct(orig_val)
-              !identical(orig_datetime, combined_datetime)
+              orig_datetime_truncated <- as.POSIXct(format(orig_datetime, "%Y-%m-%d %H:%M:%S"))
+              
+              # Truncate combined datetime to seconds as well
+              combined_datetime_truncated <- as.POSIXct(format(combined_datetime, "%Y-%m-%d %H:%M:%S"))
+              
+              # Compare the truncated values
+              !identical(orig_datetime_truncated, combined_datetime_truncated)
             }, error = function(e) {
               TRUE  # If parsing fails, assume modified
             })

--- a/modules/error_flag-4-modal_edit_trip-update_preview.R
+++ b/modules/error_flag-4-modal_edit_trip-update_preview.R
@@ -37,33 +37,103 @@ modal_update_trip_server <- function(id, trip_editor_input, selected_recid) {
         var_name <- tripeditor.cols[i]
         var_input_name <- input_tripeditor.cols[i]
 
-        compare_var <- as.data.frame(
-          cbind(var_name,
-                # original value
-                rval$orig_trip_record[[var_name]],
-                # updated value
-                trip_editor_input[[var_input_name]]
-                )
+        # Get original and updated values
+        orig_val <- rval$orig_trip_record[[var_name]]
+        updated_val <- trip_editor_input[[var_input_name]]
+        
+        # Handle datetime columns specially
+        if(var_name %in% c("depart_time_timestamp", "arrival_time_timestamp")) {
+          # Convert original datetime to character for display
+          orig_val_display <- if(is.null(orig_val) || is.na(orig_val)) {
+            ""
+          } else {
+            format(as.POSIXct(orig_val), "%Y-%m-%d %H:%M:%S")
+          }
+          
+          # For the new split date/time inputs, combine date and time parts
+          date_input <- trip_editor_input[[paste0(var_input_name, "_date")]]
+          time_input <- trip_editor_input[[paste0(var_input_name, "_time")]]
+          
+          # Combine date and time inputs
+          if(is.null(date_input) || is.null(time_input) || time_input == "") {
+            updated_val_display <- ""
+            combined_datetime <- NA
+          } else {
+            # Combine date and time
+            datetime_string <- paste(date_input, time_input)
+            updated_val_display <- datetime_string
+            combined_datetime <- tryCatch({
+              as.POSIXct(datetime_string)
+            }, error = function(e) {
+              NA
+            })
+          }
+          
+          # Compare original datetime with combined updated value
+          is_modified <- if(is.null(orig_val) || is.na(orig_val)) {
+            !is.na(combined_datetime)
+          } else if(is.na(combined_datetime)) {
+            TRUE
+          } else {
+            tryCatch({
+              orig_datetime <- as.POSIXct(orig_val)
+              !identical(orig_datetime, combined_datetime)
+            }, error = function(e) {
+              TRUE  # If parsing fails, assume modified
+            })
+          }
+          
+        } else {
+          # For non-datetime columns, use original logic
+          orig_val_display <- as.character(orig_val)
+          updated_val_display <- as.character(updated_val)
+          is_modified <- !identical(as.character(orig_val), as.character(updated_val))
+        }
+
+        compare_var <- data.frame(
+          Variable = var_name,
+          `Original Value` = orig_val_display,
+          `Updated Value` = updated_val_display,
+          mod = ifelse(is_modified, 1, 0),
+          stringsAsFactors = FALSE
         )
 
         # create df with original and updated values
-        compare_table <- rbind(compare_table,
-                               compare_var)
+        compare_table <- rbind(compare_table, compare_var)
       }
-      # browser()
 
-      names(compare_table) <- c("Variable","Original Value","Updated Value")
-
-      # detect if values are modified
-      rval$compare_table <- compare_table %>%
-        mutate(mod=case_when(`Original Value`==`Updated Value`~0,
-                             TRUE~1))
+      names(compare_table) <- c("Variable","Original Value","Updated Value", "mod")
+      rval$compare_table <- compare_table
 
       # update trip
       trip <- NULL
       for(var_name in names(rval$orig_trip_record)){
         if(var_name %in% tripeditor.cols){
-          row <- as.data.frame(trip_editor_input[[paste0("data_edit-",var_name)]])
+          # Get the input value
+          input_val <- trip_editor_input[[paste0("data_edit-",var_name)]]
+          
+          # Handle datetime columns specially
+          if(var_name %in% c("depart_time_timestamp", "arrival_time_timestamp")) {
+            # For split date/time inputs, combine them
+            date_input <- trip_editor_input[[paste0("data_edit-", var_name, "_date")]]
+            time_input <- trip_editor_input[[paste0("data_edit-", var_name, "_time")]]
+            
+            if(is.null(date_input) || is.null(time_input) || time_input == "") {
+              processed_val <- NA
+            } else {
+              # Combine date and time
+              datetime_string <- paste(date_input, time_input)
+              processed_val <- tryCatch({
+                as.POSIXct(datetime_string)
+              }, error = function(e) {
+                # If parsing fails, keep original value
+                rval$orig_trip_record[[var_name]]
+              })
+            }
+            row <- as.data.frame(processed_val)
+          } else {
+            row <- as.data.frame(input_val)
+          }
         } else{
           row <- as.data.frame(rval$orig_trip_record[[var_name]])
         }

--- a/modules/error_flag-4-modal_edit_trip.R
+++ b/modules/error_flag-4-modal_edit_trip.R
@@ -72,9 +72,8 @@ modal_edit_trip_server <- function(id, selected_recid) {
                         fluidRow(
                           class = "bottom-spacing",
                           # timestamps
-                          # TODO: find better way to select date and time
-                          column(6, textInputSimple(df = rval$trip_record, var_name = ns("data_edit-depart_time_timestamp")),
-                                    textInputSimple(df = rval$trip_record, var_name = ns("data_edit-arrival_time_timestamp"))),
+                          column(6, datetimeInputSimple(df = rval$trip_record, var_name = ns("data_edit-depart_time_timestamp")),
+                                    datetimeInputSimple(df = rval$trip_record, var_name = ns("data_edit-arrival_time_timestamp"))),
                           # trip distance
                           column(6, numericInputSimple(df = rval$trip_record, var_name = ns("data_edit-distance_miles"), min = 0))),
 


### PR DESCRIPTION
@Joanneylin could you please review these changes that I put together (with help from Claude) as a way to solve Issue #2? The `depart_time_timestamp` and `arrival_time_timestamp` are both now stored and processed as POSIXct values rather than strings, and are also edited with date-picker controls in the Trip Record Editor screen.  

I found that even when I don't edit values, these fields show up as changed fields in the "Update Trip Record Preview" screen.  I think this might have to do with the precision the fields are set at in SQL Server, which is nanosecond precision and probably a bit more finicky than we need for trip data, no?  But that's a separate issue that I'd be happy to work on another day.  